### PR TITLE
feat: add ai-friendly JSON files

### DIFF
--- a/src/params/scope.ts
+++ b/src/params/scope.ts
@@ -1,0 +1,3 @@
+import type { ParamMatcher } from '@sveltejs/kit';
+
+export const match: ParamMatcher = (value) => value.startsWith('@');

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -18,6 +18,11 @@
 
 <svelte:head>
 	<link rel="icon" href={favicon} />
+	<title>replacements.fyi - performant, safer npm package alternatives</title>
+	<meta
+		name="description"
+		content="Find more performant and safer replacements for outdated or unnecessary npm packages."
+	/>
 </svelte:head>
 
 <ThemeToggle />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -36,7 +36,7 @@
 			}}
 			class="search-form"
 		>
-			<Autocomplete items={packages} placeholder="e.g. is-number" name="package" />
+			<Autocomplete items={packages} placeholder="e.g. is-number" name="package" autofocus />
 			<button type="submit" class="submit-btn" aria-label="Search">→</button>
 		</form>
 

--- a/src/routes/[package].json/+server.ts
+++ b/src/routes/[package].json/+server.ts
@@ -1,0 +1,22 @@
+import { all } from 'module-replacements';
+import { error, json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+export const prerender = true;
+
+export const GET: RequestHandler = ({ params }) => {
+	const name = params.package;
+	if (!name || !Object.hasOwn(all.mappings, name)) {
+		throw error(404, `No replacement found for "${name}"`);
+	}
+	const mapping = all.mappings[name];
+
+	const replacements = mapping.replacements.map((key) => all.replacements[key]);
+
+	return json({
+		name: mapping.moduleName,
+		type: mapping.type,
+		url: mapping.url,
+		replacements
+	});
+};

--- a/src/routes/[package]/+page.svelte
+++ b/src/routes/[package]/+page.svelte
@@ -7,7 +7,9 @@
 	let { params } = $props();
 
 	let package_name = $derived(params.package ?? '');
-	let mapping = $derived(all.mappings[package_name]);
+	let mapping = $derived(
+		Object.hasOwn(all.mappings, package_name) ? all.mappings[package_name] : undefined
+	);
 
 	let resolved_replacements = $derived(
 		mapping ? mapping.replacements.map((key: string) => ({ key, data: all.replacements[key] })) : []
@@ -58,6 +60,16 @@
 		].filter((c) => c.engines.length > 0);
 	}
 </script>
+
+<svelte:head>
+	{#if mapping}
+		<title>{package_name} - replacements.fyi</title>
+		<meta name="description" content="Replacements for the '{package_name}' npm package." />
+	{:else}
+		<title>{package_name} not found - replacements.fyi</title>
+		<meta name="description" content="No replacement found for the '{package_name}' npm package." />
+	{/if}
+</svelte:head>
 
 <a href={resolve('/')} class="back-link"><MrE18e /></a>
 <div class="page">

--- a/src/routes/[scope=scope]/[name].json/+server.ts
+++ b/src/routes/[scope=scope]/[name].json/+server.ts
@@ -1,0 +1,22 @@
+import { all } from 'module-replacements';
+import { error, json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+export const prerender = true;
+
+export const GET: RequestHandler = ({ params }) => {
+	const full = `${params.scope}/${params.name}`;
+	if (!Object.hasOwn(all.mappings, full)) {
+		throw error(404, `No replacement found for "${full}"`);
+	}
+	const mapping = all.mappings[full];
+
+	const replacements = mapping.replacements.map((key) => all.replacements[key]);
+
+	return json({
+		name: mapping.moduleName,
+		type: mapping.type,
+		url: mapping.url,
+		replacements
+	});
+};

--- a/src/routes/llms.txt/+server.ts
+++ b/src/routes/llms.txt/+server.ts
@@ -1,0 +1,39 @@
+import { all } from 'module-replacements';
+import type { RequestHandler } from './$types';
+
+export const prerender = true;
+
+export const GET: RequestHandler = ({ url }) => {
+	const origin = url.origin;
+	const names = Object.keys(all.mappings).sort();
+
+	const lines = [
+		'# replacements.fyi',
+		'',
+		'> Find more performant and safer replacements for outdated or unnecessary npm packages.',
+		'',
+		'Each known package has a human-readable page and a machine-readable JSON equivalent:',
+		'',
+		`- HTML: ${origin}/<package>`,
+		`- JSON: ${origin}/<package>.json`,
+		'',
+		'The JSON response shape is `{ name, type, url?, replacements: [...] }`, where each',
+		'replacement has a `type` (`native`, `simple`, `documented`, or `removal`) and',
+		'type-specific fields (e.g. `description`, `example`, `replacementModule`, `url`).',
+		'',
+		'## packages',
+		'',
+		...names.map((name) => {
+			const html = `${origin}/${encodeURIComponent(name)}`;
+			const jsonPath = name.startsWith('@')
+				? `${origin}/${name}.json`
+				: `${origin}/${encodeURIComponent(name)}.json`;
+			return `- [${name}](${html}) ([json](${jsonPath}))`;
+		}),
+		''
+	];
+
+	return new Response(lines.join('\n'), {
+		headers: { 'content-type': 'text/plain; charset=utf-8' }
+	});
+};

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -12,7 +12,13 @@ const config = {
 		adapter: adapter({ fallback: '404.html' }),
 		experimental: { remoteFunctions: true },
 		prerender: {
-			entries: Object.keys(all.mappings).map((key) => `/${encodeURIComponent(key)}`)
+			entries: [
+				'/llms.txt',
+				...Object.keys(all.mappings).flatMap((key) => [
+					`/${encodeURIComponent(key)}`,
+					key.startsWith('@') ? `/${key}.json` : `/${encodeURIComponent(key)}.json`
+				])
+			]
 		}
 	}
 };


### PR DESCRIPTION
This adds JSON equivalents to each package page along with a dynamically
generated `llms.txt` to tell an agent how/why to use them.

It also adds a `scope` params matcher so we can do `/@foo/bar.json`
(seemed to fail without having its own route).

I used some Claude to help with this, so let me know if any of it is not the "svelte way" so I can learn.
