### PR TITLE
Show drop down even on exact

### DIFF
--- a/src/lib/Autocomplete.svelte
+++ b/src/lib/Autocomplete.svelte
@@ -15,8 +15,6 @@
 		value.length > 0 ? items.filter((item) => item.includes(value)).slice(0, 20) : []
 	);
 
-	let exact = $derived(filtered.length === 1 && filtered[0] === value);
-
 	let input: HTMLInputElement;
 
 	function select(item: string) {
@@ -75,7 +73,7 @@
 		aria-controls="autocomplete-list"
 		aria-activedescendant={active_index >= 0 ? `option-${active_index}` : undefined}
 	/>
-	{#if open && filtered.length > 0 && !exact}
+	{#if open && filtered.length > 0}
 		<ul id="autocomplete-list" class="suggestions" role="listbox">
 			{#each filtered as item, i (item)}
 				<li

--- a/src/lib/Autocomplete.svelte.test.ts
+++ b/src/lib/Autocomplete.svelte.test.ts
@@ -63,12 +63,12 @@ test('Escape closes the dropdown', async () => {
 	expect(page.getByRole('listbox').elements()).toHaveLength(0);
 });
 
-test('exact match hides dropdown', async () => {
+test('exact match does not hide dropdown', async () => {
 	render(Autocomplete, { items });
 	const input = page.getByRole('combobox');
 	await userEvent.click(input);
 	await userEvent.keyboard('cherry');
-	expect(page.getByRole('listbox').elements()).toHaveLength(0);
+	expect(page.getByRole('listbox').elements()).toHaveLength(1);
 });
 
 test('clicking a suggestion selects it', async () => {


### PR DESCRIPTION
So, when testing the website with Express yesterday, I was typing in `qs` but no option appeared in the drop-down. However, when I type in `q`, it appears at the bottom of a long list. See currnet behaviour here

<img width="1032" height="963" alt="Screen Recording 2026-04-23 at 11 09 31 am" src="https://github.com/user-attachments/assets/42994470-c1bf-4469-a8b8-d8a2fda6fb30" />

Personally, I feel this creates a slightly weird UX. What if I am not 100% sure of the package I am looking for, or this makes me think `qs` is not an option. I think it's better UX to keep the `qs` option in there and match on exact.

<img width="1032" height="963" alt="Screen Recording 2026-04-23 at 11 10 21 am" src="https://github.com/user-attachments/assets/95cc6e01-0cf4-4dda-ab77-33d409a1b320" />

Of course if you think its fine feel free to digard the PR