### PR TITLE
Swapped out AutoComplete for Simpler SearchBox in All Packages Page

### DIFF
--- a/src/lib/FilterInput.svelte
+++ b/src/lib/FilterInput.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+	import type { HTMLInputAttributes } from 'svelte/elements';
+
+	type Props = {
+		value?: string;
+	} & HTMLInputAttributes;
+
+	let { value = $bindable(''), ...rest }: Props = $props();
+</script>
+
+<input bind:value {...rest} type="text" autocomplete="off" spellcheck="false" role="searchbox" />
+
+<style>
+	input {
+		background: transparent;
+		border: none;
+		outline: none;
+		color: var(--text);
+		font-family: inherit;
+		font-size: 0.9375rem;
+		width: 100%;
+		padding: 0.625rem 0.75rem;
+		box-sizing: border-box;
+	}
+
+	input::placeholder {
+		color: var(--subtle);
+	}
+</style>

--- a/src/routes/packages/+page.svelte
+++ b/src/routes/packages/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { resolve } from '$app/paths';
 	import { all } from 'module-replacements';
-	import Autocomplete from '$lib/Autocomplete.svelte';
+	import FilterInput from '$lib/FilterInput.svelte';
 	import MrE18e from '$lib/MrE18e.svelte';
 
 	const packages = Object.keys(all.mappings).sort();
@@ -30,7 +30,7 @@
 	</header>
 
 	<div class="filters">
-		<Autocomplete items={packages} placeholder="Filter packages..." bind:value={filter} />
+		<FilterInput placeholder="Filter packages..." bind:value={filter} />
 	</div>
 
 	<ul class="package-list">
@@ -97,6 +97,7 @@
 
 	.filters {
 		display: flex;
+		flex: 1;
 		align-items: center;
 		margin-bottom: 1.5rem;
 		border: 1px solid var(--border-strong);

--- a/src/routes/packages/+page.svelte
+++ b/src/routes/packages/+page.svelte
@@ -30,7 +30,7 @@
 	</header>
 
 	<div class="filters">
-		<FilterInput placeholder="Filter packages..." bind:value={filter} />
+		<FilterInput placeholder="Filter packages..." bind:value={filter} autofocus />
 	</div>
 
 	<ul class="package-list">


### PR DESCRIPTION
Swapped out the AutoComplete component for a simpler input, as it was doubling up the drop-down on the all packages page.

Made the new search input a component with located styles. Did not add tests as its a very basic component. 