### PR TITLE
Swapped out example for a working one

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -5,7 +5,7 @@
 	import Autocomplete from '$lib/Autocomplete.svelte';
 	import MrE18e from '$lib/MrE18e.svelte';
 
-	const examples = ['is-number', 'left-pad', 'is-array', 'object-assign'];
+	const examples = ['is-number', 'left-pad', 'is-odd', 'object-assign'];
 	const packages = Object.keys(all.mappings);
 </script>
 

--- a/tests/app.e2e.ts
+++ b/tests/app.e2e.ts
@@ -7,7 +7,7 @@ test.describe('Home page', () => {
 		await expect(page.getByRole('button', { name: 'Search' })).toBeVisible();
 		await expect(page.getByRole('link', { name: 'is-number' })).toBeVisible();
 		await expect(page.getByRole('link', { name: 'left-pad' })).toBeVisible();
-		await expect(page.getByRole('link', { name: 'is-array' })).toBeVisible();
+		await expect(page.getByRole('link', { name: 'is-odd' })).toBeVisible();
 		await expect(page.getByRole('link', { name: 'object-assign' })).toBeVisible();
 	});
 


### PR DESCRIPTION
Swapped out the example with no suggestion for one that works. Pick `is-odd` cus its funny.

Closes #19 

<img width="1995" height="1770" alt="is-odd-replacements-fyi-04-24-2026_11_47_AM" src="https://github.com/user-attachments/assets/f0cd330b-62ae-4f72-9cf9-baec40b51b9f" />


