### PR TITLE
fix: add correct `origin` to svelte config

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -12,6 +12,7 @@ const config = {
 		adapter: adapter({ fallback: '404.html' }),
 		experimental: { remoteFunctions: true },
 		prerender: {
+			origin: 'https://replacements.fyi',
 			entries: [
 				'/llms.txt',
 				...Object.keys(all.mappings).flatMap((key) => [


### PR DESCRIPTION
fixes #34
