### PR TITLE
feat: add runtime toggle

### DIFF
--- a/src/lib/RuntimeToggle.svelte
+++ b/src/lib/RuntimeToggle.svelte
@@ -34,7 +34,6 @@
 		border-radius: 6px;
 		color: var(--muted);
 		font-family: inherit;
-		font-size: 16px;
 		padding: 0.3rem 0.55rem;
 		margin: 0;
 		cursor: pointer;

--- a/src/lib/RuntimeToggle.svelte
+++ b/src/lib/RuntimeToggle.svelte
@@ -7,6 +7,7 @@
 	<select
 		value={runtime.pref}
 		name="runtime"
+		aria-label="Runtime"
 		onchange={(e) => runtime.set((e.currentTarget as HTMLSelectElement).value as Runtime)}
 	>
 		{#each runtimes as opt (opt.value)}

--- a/src/lib/RuntimeToggle.svelte
+++ b/src/lib/RuntimeToggle.svelte
@@ -2,7 +2,7 @@
 	import { runtime, runtimes, type Runtime } from '$lib/runtime.svelte';
 </script>
 
-<label class="toggle" aria-label="Runtime">
+<label class="toggle">
 	<span class="label">runtime</span>
 	<select
 		value={runtime.pref}

--- a/src/lib/RuntimeToggle.svelte
+++ b/src/lib/RuntimeToggle.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+	import { runtime, runtimes, type Runtime } from '$lib/runtime.svelte';
+</script>
+
+<label class="toggle" aria-label="Runtime">
+	<span class="label">runtime</span>
+	<select
+		value={runtime.pref}
+		onchange={(e) => runtime.set((e.currentTarget as HTMLSelectElement).value as Runtime)}
+	>
+		{#each runtimes as opt (opt.value)}
+			<option value={opt.value}>{opt.label}</option>
+		{/each}
+	</select>
+</label>
+
+<style>
+	.toggle {
+		position: fixed;
+		top: 0.75rem;
+		right: 10.5rem;
+		z-index: 100;
+		display: inline-flex;
+		align-items: center;
+		gap: 0.4rem;
+		border: 1px solid var(--border);
+		border-radius: 6px;
+		background: var(--surface);
+		padding: 0 0.55rem;
+	}
+
+	.label {
+		color: var(--subtle);
+		font-size: 0.7rem;
+		line-height: 1;
+	}
+
+	select {
+		background: none;
+		border: none;
+		color: var(--muted);
+		font-family: inherit;
+		font-size: 0.7rem;
+		padding: 0.3rem 0;
+		cursor: pointer;
+		line-height: 1;
+		outline: none;
+	}
+
+	select:hover {
+		color: var(--accent);
+	}
+</style>

--- a/src/lib/RuntimeToggle.svelte
+++ b/src/lib/RuntimeToggle.svelte
@@ -6,6 +6,7 @@
 	<span class="label">runtime:</span>
 	<select
 		value={runtime.pref}
+		name="runtime"
 		onchange={(e) => runtime.set((e.currentTarget as HTMLSelectElement).value as Runtime)}
 	>
 		{#each runtimes as opt (opt.value)}

--- a/src/lib/RuntimeToggle.svelte
+++ b/src/lib/RuntimeToggle.svelte
@@ -2,8 +2,8 @@
 	import { runtime, runtimes, type Runtime } from '$lib/runtime.svelte';
 </script>
 
-<label class="toggle">
-	<span class="label">runtime</span>
+<label class="field">
+	<span class="label">runtime:</span>
 	<select
 		value={runtime.pref}
 		onchange={(e) => runtime.set((e.currentTarget as HTMLSelectElement).value as Runtime)}
@@ -15,33 +15,27 @@
 </label>
 
 <style>
-	.toggle {
-		position: fixed;
-		top: 0.75rem;
-		right: 10.5rem;
-		z-index: 100;
+	.field {
 		display: inline-flex;
 		align-items: center;
-		gap: 0.4rem;
-		border: 1px solid var(--border);
-		border-radius: 6px;
-		background: var(--surface);
-		padding: 0 0.55rem;
+		gap: 0.5rem;
+		line-height: 1;
 	}
 
 	.label {
 		color: var(--subtle);
-		font-size: 0.7rem;
-		line-height: 1;
 	}
 
 	select {
-		background: none;
-		border: none;
+		appearance: none;
+		background: var(--surface);
+		border: 1px solid var(--border);
+		border-radius: 6px;
 		color: var(--muted);
 		font-family: inherit;
-		font-size: 0.7rem;
-		padding: 0.3rem 0;
+		font-size: 16px;
+		padding: 0.3rem 0.55rem;
+		margin: 0;
 		cursor: pointer;
 		line-height: 1;
 		outline: none;
@@ -49,5 +43,10 @@
 
 	select:hover {
 		color: var(--accent);
+		border-color: var(--accent);
+	}
+
+	select:focus-visible {
+		border-color: var(--accent);
 	}
 </style>

--- a/src/lib/engines.ts
+++ b/src/lib/engines.ts
@@ -1,0 +1,33 @@
+import type { EngineConstraint } from 'module-replacements';
+import type { Runtime } from './runtime.svelte';
+
+export const browser_engines = [
+	'chrome',
+	'firefox',
+	'safari',
+	'edge',
+	'safari_ios',
+	'chrome_android',
+	'firefox_android',
+	'webview_android',
+	'webview_ios',
+	'samsunginternet_android',
+	'opera',
+	'opera_android'
+];
+
+export const runtime_engines = ['nodejs', 'deno', 'bun', 'cloudflare'];
+
+export function engine_matches_runtime(engine: string, runtime: Runtime): boolean {
+	if (runtime === 'any') return true;
+	if (runtime === 'browser') return browser_engines.includes(engine);
+	return engine === runtime;
+}
+
+export function engines_match_runtime(
+	engines: EngineConstraint[] | undefined,
+	runtime: Runtime
+): boolean {
+	if (runtime === 'any' || !engines || engines.length === 0) return true;
+	return engines.some((e) => engine_matches_runtime(e.engine, runtime));
+}

--- a/src/lib/runtime.svelte.ts
+++ b/src/lib/runtime.svelte.ts
@@ -1,0 +1,30 @@
+export type Runtime = 'any' | 'nodejs' | 'bun' | 'deno' | 'cloudflare' | 'browser';
+
+export const runtimes: { value: Runtime; label: string }[] = [
+	{ value: 'any', label: 'Any' },
+	{ value: 'nodejs', label: 'Node' },
+	{ value: 'bun', label: 'Bun' },
+	{ value: 'deno', label: 'Deno' },
+	{ value: 'cloudflare', label: 'Cloudflare' },
+	{ value: 'browser', label: 'Browser' }
+];
+
+const cookie_re = new RegExp(`(?:^|;\\s*)runtime=(${runtimes.map((r) => r.value).join('|')})`);
+
+function read_cookie(): Runtime {
+	if (typeof document === 'undefined') return 'any';
+	const match = document.cookie.match(cookie_re);
+	return (match?.[1] as Runtime) ?? 'any';
+}
+
+class RuntimeStore {
+	pref = $state<Runtime>(read_cookie());
+
+	set(pref: Runtime) {
+		this.pref = pref;
+		if (typeof document === 'undefined') return;
+		document.cookie = `runtime=${pref}; path=/; max-age=31536000; samesite=lax`;
+	}
+}
+
+export const runtime = new RuntimeStore();

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -8,7 +8,6 @@
 	import '@fontsource/ibm-plex-mono/700.css';
 	import favicon from '$lib/assets/favicon.svg';
 	import ThemeToggle from '$lib/ThemeToggle.svelte';
-	import RuntimeToggle from '$lib/RuntimeToggle.svelte';
 	import './global.css';
 	import { setupViewTransition } from 'sveltekit-view-transition';
 
@@ -26,7 +25,6 @@
 	/>
 </svelte:head>
 
-<RuntimeToggle />
 <ThemeToggle />
 
 {@render children()}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -8,6 +8,7 @@
 	import '@fontsource/ibm-plex-mono/700.css';
 	import favicon from '$lib/assets/favicon.svg';
 	import ThemeToggle from '$lib/ThemeToggle.svelte';
+	import RuntimeToggle from '$lib/RuntimeToggle.svelte';
 	import './global.css';
 	import { setupViewTransition } from 'sveltekit-view-transition';
 
@@ -25,6 +26,7 @@
 	/>
 </svelte:head>
 
+<RuntimeToggle />
 <ThemeToggle />
 
 {@render children()}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -36,7 +36,13 @@
 			}}
 			class="search-form"
 		>
-			<Autocomplete items={packages} placeholder="e.g. is-number" name="package" autofocus />
+			<Autocomplete
+				items={packages}
+				placeholder="e.g. is-number"
+				name="package"
+				aria-label="Package name"
+				autofocus
+			/>
 			<button type="submit" class="submit-btn" aria-label="Search">→</button>
 		</form>
 

--- a/src/routes/[package]/+page.svelte
+++ b/src/routes/[package]/+page.svelte
@@ -9,6 +9,8 @@
 	} from 'module-replacements';
 	import { highlight } from './highlight.remote';
 	import ReplacementsTitle from '$lib/ReplacementsTitle.svelte';
+	import { browser_engines, runtime_engines, engines_match_runtime } from '$lib/engines';
+	import { runtime } from '$lib/runtime.svelte';
 
 	let { params } = $props();
 
@@ -21,21 +23,15 @@
 		mapping ? mapping.replacements.map((key: string) => ({ key, data: all.replacements[key] })) : []
 	);
 
-	const browser_engines = [
-		'chrome',
-		'firefox',
-		'safari',
-		'edge',
-		'safari_ios',
-		'chrome_android',
-		'firefox_android',
-		'webview_android',
-		'webview_ios',
-		'samsunginternet_android',
-		'opera',
-		'opera_android'
-	];
-	const runtime_engines = ['nodejs', 'deno', 'bun'];
+	let visible_replacements = $derived(
+		resolved_replacements.filter(({ data }) => engines_match_runtime(data.engines, runtime.pref))
+	);
+
+	let count_label = $derived(
+		visible_replacements.length === resolved_replacements.length
+			? `${resolved_replacements.length}`
+			: `${visible_replacements.length} of ${resolved_replacements.length}`
+	);
 
 	function get_url(url: KnownUrl): string {
 		if (typeof url === 'string') return url;
@@ -116,9 +112,16 @@
 		</header>
 
 		<section class="replacements">
-			<p class="comment">// replacements ({resolved_replacements.length})</p>
+			<p class="comment">// replacements ({count_label})</p>
 
-			{#each resolved_replacements as { key, data } (key)}
+			{#if visible_replacements.length === 0}
+				<p class="description">
+					No replacements match the <span class="teal">{runtime.pref}</span> runtime. Try switching
+					to <span class="teal">any</span>.
+				</p>
+			{/if}
+
+			{#each visible_replacements as { key, data } (key)}
 				<div class="replacement">
 					<h2 class="replacement-id">{key}</h2>
 					<span class="badge">{get_type_display_name(data.type, is_in_native_manifest(key))}</span>

--- a/src/routes/[package]/+page.svelte
+++ b/src/routes/[package]/+page.svelte
@@ -9,6 +9,7 @@
 	} from 'module-replacements';
 	import { highlight } from './highlight.remote';
 	import ReplacementsTitle from '$lib/ReplacementsTitle.svelte';
+	import RuntimeToggle from '$lib/RuntimeToggle.svelte';
 	import { browser_engines, runtime_engines, engines_match_runtime } from '$lib/engines';
 	import { runtime } from '$lib/runtime.svelte';
 
@@ -110,6 +111,13 @@
 			<h1 class="pkg-name"><span class="pkg">{package_name}</span></h1>
 			<p class="pkg-type">type: "{mapping.type}"</p>
 		</header>
+
+		<section class="preferences">
+			<p class="comment">// preferences</p>
+			<div class="prefs-list">
+				<RuntimeToggle />
+			</div>
+		</section>
 
 		<section class="replacements">
 			<p class="comment">// replacements ({count_label})</p>
@@ -253,6 +261,16 @@
 
 	.replacements > .comment {
 		margin-bottom: 1.5rem;
+	}
+
+	.preferences {
+		margin-bottom: 2rem;
+	}
+
+	.prefs-list {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.5rem;
 	}
 
 	.replacement {

--- a/src/routes/[package]/+page.svelte
+++ b/src/routes/[package]/+page.svelte
@@ -276,6 +276,7 @@
 		display: flex;
 		flex-wrap: wrap;
 		gap: 0.5rem;
+		font-size: 0.9rem;
 	}
 
 	.replacement {

--- a/tests/app.e2e.ts
+++ b/tests/app.e2e.ts
@@ -64,7 +64,7 @@ test.describe('Package detail page', () => {
 
 test.describe('Runtime switcher', () => {
 	test('defaults to Any and persists selection via cookie', async ({ page }) => {
-		await page.goto('/');
+		await page.goto('/is-number');
 		const select = page.getByRole('combobox', { name: 'Runtime' });
 		await expect(select).toHaveValue('any');
 

--- a/tests/app.e2e.ts
+++ b/tests/app.e2e.ts
@@ -3,7 +3,7 @@ import { test, expect } from '@playwright/test';
 test.describe('Home page', () => {
 	test('loads with search form and example links', async ({ page }) => {
 		await page.goto('/');
-		await expect(page.getByRole('combobox')).toBeVisible();
+		await expect(page.getByRole('combobox', { name: 'Package name' })).toBeVisible();
 		await expect(page.getByRole('button', { name: 'Search' })).toBeVisible();
 		await expect(page.getByRole('link', { name: 'is-number' })).toBeVisible();
 		await expect(page.getByRole('link', { name: 'left-pad' })).toBeVisible();
@@ -20,7 +20,7 @@ test.describe('Home page', () => {
 
 	test('typing in search shows autocomplete suggestions', async ({ page }) => {
 		await page.goto('/');
-		const input = page.getByRole('combobox');
+		const input = page.getByRole('combobox', { name: 'Package name' });
 		await input.fill('is-n');
 		await expect(page.getByRole('option', { name: /is-number/ })).toHaveCount(2);
 	});
@@ -33,7 +33,7 @@ test.describe('Home page', () => {
 
 	test('submitting search navigates to detail page', async ({ page }) => {
 		await page.goto('/');
-		const input = page.getByRole('combobox');
+		const input = page.getByRole('combobox', { name: 'Package name' });
 		await input.fill('is-number');
 		await page.getByRole('button', { name: 'Search' }).click();
 		await expect(page).toHaveURL(/\/is-number/);
@@ -59,5 +59,33 @@ test.describe('Package detail page', () => {
 		// The back link contains "mr.e18e" text
 		await page.locator('.back-link').click();
 		await expect(page).toHaveURL('/');
+	});
+});
+
+test.describe('Runtime switcher', () => {
+	test('defaults to Any and persists selection via cookie', async ({ page }) => {
+		await page.goto('/');
+		const select = page.getByRole('combobox', { name: 'Runtime' });
+		await expect(select).toHaveValue('any');
+
+		await select.selectOption('bun');
+		await expect(select).toHaveValue('bun');
+
+		const cookies = await page.context().cookies();
+		expect(cookies.find((c) => c.name === 'runtime')?.value).toBe('bun');
+
+		await page.reload();
+		await expect(page.getByRole('combobox', { name: 'Runtime' })).toHaveValue('bun');
+	});
+
+	test('filters replacements on detail page when switching runtime', async ({ page }) => {
+		// buffer-from has a node-only replacement
+		await page.goto('/buffer-from');
+		const comment = page.locator('.replacements > .comment');
+		await expect(comment).toHaveText('// replacements (1)');
+
+		await page.getByRole('combobox', { name: 'Runtime' }).selectOption('browser');
+		await expect(comment).toHaveText('// replacements (0 of 1)');
+		await expect(page.getByText(/No replacements match the/)).toBeVisible();
 	});
 });


### PR DESCRIPTION
This adds a runtime toggle to the header alongside the theme toggle.

If you select anything other than `any`, the replacements list is
filtered down to those with no engines, or with engines matching your
selection.

As far as I understand, the static pages svelte generates will list all
replacements and this visible condition will run in hydration code
clientside later on.

Closes #26.
