### PR TITLE
fix: lowercase resolved packages

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -31,7 +31,11 @@
 				if (package_name) {
 					const input = e.currentTarget.querySelector('input')!;
 					input.style.setProperty('view-transition-name', 'package-name');
-					goto(resolve('/[package]', { package: encodeURIComponent(package_name.toString()) }));
+					goto(
+						resolve('/[package]', {
+							package: encodeURIComponent(package_name.toString().toLowerCase())
+						})
+					);
 				}
 			}}
 			class="search-form"


### PR DESCRIPTION
If someone types in `CHALK`, we should still go to the `chalk` route.
