### PR TITLE
fix: tweak some a11y things

### DIFF
--- a/src/lib/Controls.svelte
+++ b/src/lib/Controls.svelte
@@ -49,7 +49,7 @@
 		font-family: inherit;
 		font-size: 0.7rem;
 		line-height: 1;
-		color: var(--subtle);
+		color: var(--subtle-contrast);
 		background: var(--surface);
 		border: 1px solid var(--border);
 		border-radius: 6px;

--- a/src/lib/ThemeToggle.svelte
+++ b/src/lib/ThemeToggle.svelte
@@ -43,7 +43,7 @@
 	.seg {
 		background: none;
 		border: none;
-		color: var(--subtle);
+		color: var(--subtle-contrast);
 		font-family: inherit;
 		font-size: 0.7rem;
 		padding: 0.3rem 0.55rem;
@@ -63,7 +63,7 @@
 	}
 
 	.seg.active {
-		color: var(--accent);
+		color: var(--accent-contrast);
 		background: color-mix(in srgb, var(--accent) 10%, transparent);
 	}
 </style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -19,17 +19,19 @@
 	}
 </script>
 
-<div class="page">
+<main class="page">
 	<div class="container">
-		<div class="title">
-			<ReplacementsTitle />
-		</div>
+		<header>
+			<div class="title">
+				<ReplacementsTitle />
+			</div>
 
-		<p class="params">
-			<span class="paren">(</span><span class="param">module_replacements</span><span class="paren"
-				>)</span
-			>
-		</p>
+			<p class="params">
+				<span class="paren">(</span><span class="param">module_replacements</span><span
+					class="paren">)</span
+				>
+			</p>
+		</header>
 
 		<p class="tagline">type a package name. we'll tell you what you don't need.</p>
 
@@ -73,7 +75,7 @@
 
 		<a href={resolve('/packages')} class="all-packages-link">Browse all packages →</a>
 	</div>
-</div>
+</main>
 
 <style>
 	.page {

--- a/src/routes/[[scope=scope]]/[package]/+page.svelte
+++ b/src/routes/[[scope=scope]]/[package]/+page.svelte
@@ -89,11 +89,13 @@
 </svelte:head>
 
 <a href={resolve('/')} class="back-link"><ReplacementsTitle /></a>
-<div class="page">
+<main class="page">
 	{#if !mapping}
 		<div class="not-found">
-			<p class="comment">// 404</p>
-			<h1>"<span class="pkg">{package_name}</span>" not found</h1>
+			<header>
+				<p class="comment">// 404</p>
+				<h1>"<span class="pkg">{package_name}</span>" not found</h1>
+			</header>
 			<p>we don't have a replacement for "{package_name}"...yet</p>
 			<p>
 				if you have a suggestion, please <a
@@ -211,7 +213,7 @@
 			{/each}
 		</section>
 	{/if}
-</div>
+</main>
 
 <style>
 	.page {
@@ -300,7 +302,7 @@
 	.badge {
 		display: inline-block;
 		background: var(--code-bg);
-		color: var(--accent);
+		color: var(--accent-contrast);
 		padding: 0.15rem 0.5rem;
 		font-size: 0.7rem;
 		border-radius: 4px;
@@ -369,7 +371,7 @@
 	}
 
 	.engine-tab[open] > .tab-btn {
-		background: var(--accent);
+		background: var(--accent-contrast);
 		color: var(--bg);
 	}
 

--- a/src/routes/global.css
+++ b/src/routes/global.css
@@ -14,10 +14,12 @@
 	--text: #18181b;
 	--muted: #52525b;
 	--subtle: #a1a1aa;
+	--subtle-contrast: #71717a;
 	--border: #e4e4e7;
 	--border-strong: #d4d4d8;
 	--accent: #059669;
 	--accent-hover: #047857;
+	--accent-contrast: #047857;
 	--accent-tint: color-mix(in srgb, var(--accent) 10%, transparent);
 	--code-bg: #f4f4f5;
 	--input-bg: #ffffff;
@@ -30,10 +32,12 @@
 		--text: #e4e4e7;
 		--muted: #a1a1aa;
 		--subtle: #71717a;
+		--subtle-contrast: #a1a1aa;
 		--border: #3f3f46;
 		--border-strong: #52525b;
 		--accent: #10b981;
 		--accent-hover: #34d399;
+		--accent-contrast: #10b981;
 		--accent-tint: color-mix(in srgb, var(--accent) 15%, transparent);
 		--code-bg: #27272a;
 		--input-bg: #27272a;
@@ -51,10 +55,12 @@
 	--text: #e4e4e7;
 	--muted: #a1a1aa;
 	--subtle: #71717a;
+	--subtle-contrast: #a1a1aa;
 	--border: #3f3f46;
 	--border-strong: #52525b;
 	--accent: #10b981;
 	--accent-hover: #34d399;
+	--accent-contrast: #10b981;
 	--accent-tint: color-mix(in srgb, var(--accent) 15%, transparent);
 	--code-bg: #27272a;
 	--input-bg: #27272a;

--- a/src/routes/packages/+page.svelte
+++ b/src/routes/packages/+page.svelte
@@ -23,7 +23,7 @@
 
 <a href={resolve('/')} class="back-link"><ReplacementsTitle /></a>
 
-<div class="page">
+<main class="page">
 	<header class="header">
 		<p class="comment">// all packages</p>
 		<h1>Package Directory</h1>
@@ -53,7 +53,7 @@
 	{#if filtered_packages.length === 0}
 		<p class="no-results">No packages match your search.</p>
 	{/if}
-</div>
+</main>
 
 <style>
 	.page {


### PR DESCRIPTION
This does a couple of changes:

- Add `<main>` to each page
- Add `<header>` to each page
- Add `--subtle-contrast` which is basically a more contrast-friendly
  `--subtle` when needed
- Add a `--accent-contrast`, same reason as above
