### PR TITLE
Add template path to suggestion url

### DIFF
--- a/src/routes/[[scope=scope]]/[package]/+page.svelte
+++ b/src/routes/[[scope=scope]]/[package]/+page.svelte
@@ -99,7 +99,7 @@
 			<p>we don't have a replacement for "{package_name}"...yet</p>
 			<p>
 				if you have a suggestion, please <a
-					href="https://github.com/e18e/module-replacements/issues/new"
+					href="https://github.com/e18e/module-replacements/issues/new?template=1-replacement.yml"
 					target="_blank"
 					rel="noopener noreferrer">let us know</a
 				>


### PR DESCRIPTION
Noticed the path to suggest a replacement was not linking directly to the template.  This fixes this.