### PR TITLE
feat: allow package.json drop on index

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -5,7 +5,9 @@ declare global {
 		// interface Error {}
 		// interface Locals {}
 		// interface PageData {}
-		// interface PageState {}
+		interface PageState {
+			package_json?: string;
+		}
 		// interface Platform {}
 	}
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -18,7 +18,23 @@
 		// eslint-disable-next-line svelte/no-navigation-without-resolve
 		goto(package_href(package_name));
 	}
+
+	function handle_dragover(event: DragEvent) {
+		if (Array.from(event.dataTransfer?.types ?? []).includes('Files')) {
+			event.preventDefault();
+		}
+	}
+
+	async function handle_drop(event: DragEvent) {
+		const file = event.dataTransfer?.files[0];
+		if (file && file.type === 'application/json') {
+			event.preventDefault();
+			goto(resolve('/package-json'), { state: { package_json: await file.text() } });
+		}
+	}
 </script>
+
+<svelte:window ondragover={handle_dragover} ondrop={handle_drop} />
 
 <main class="page">
 	<div class="container">

--- a/src/routes/package-json/+page.svelte
+++ b/src/routes/package-json/+page.svelte
@@ -40,6 +40,18 @@
 			: scan_package_json_file.fields.package_json.issues()?.[0]?.message || ''
 	);
 
+	$effect(() => {
+		if (page.state.package_json) {
+			const result = eval_package_json(page.state.package_json);
+			if (result.success) {
+				scan_result = result;
+				scan_error = '';
+			} else {
+				scan_error = result.error;
+			}
+		}
+	});
+
 	function package_href(package_name: string) {
 		return resolve('/[[scope=scope]]/[package]', scopify(package_name));
 	}

--- a/tests/app.e2e.ts
+++ b/tests/app.e2e.ts
@@ -58,6 +58,30 @@ test.describe('Home page', () => {
 		await page.getByRole('button', { name: 'Search' }).click();
 		await expect(page).toHaveURL(/\/is-number/);
 	});
+
+	test('dropping package.json navigates to its scan results', async ({ page }) => {
+		await page.goto('/');
+		await page.evaluate(() => {
+			const file = new File(
+				[JSON.stringify({ dependencies: { 'body-parser': '^2.2.1' } })],
+				'package.json',
+				{ type: 'application/json' }
+			);
+			const data_transfer = new DataTransfer();
+			data_transfer.items.add(file);
+			window.dispatchEvent(
+				new DragEvent('drop', {
+					bubbles: true,
+					cancelable: true,
+					dataTransfer: data_transfer
+				})
+			);
+		});
+
+		await expect(page).toHaveURL(/\/package-json$/);
+		await expect(page.getByRole('heading', { name: 'Found 1 replacements' })).toBeVisible();
+		await expect(page.getByRole('link', { name: /body-parser/ })).toBeVisible();
+	});
 });
 
 test.describe('Package detail page', () => {


### PR DESCRIPTION
## Current Behavior

Dropping `package.json` on index page of replacements.fyi opens it as normal browser file preview

<img width="1280" height="825" alt="Screen Recording 2026-05-24 at 10 40 51" src="https://github.com/user-attachments/assets/85bf65bb-834b-49af-b6ee-1aa50801105c" />

_file handle unfortunately is not visible in screen recording_

## Feature Behavior

Adding `handle_dragover` and `handle_drop` event listeners to index to redirect with `package.json` data to /package-json on file drop

<img width="1280" height="825" alt="Screen Recording 2026-05-24 at 10 43 35" src="https://github.com/user-attachments/assets/f4440fc4-23d5-4857-89b4-34731990ff70" />

_file handle unfortunately is not visible in screen recording_