### PR TITLE
fix: prevent page overflow from 100vh layout

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -25,6 +25,26 @@
 	/>
 </svelte:head>
 
-<Controls />
+<div class="app">
+	<Controls />
+	<div class="page-wrapper">
+		{@render children()}
+	</div>
+</div>
 
-{@render children()}
+<style>
+	.app {
+		height: 100dvh;
+		display: flex;
+		flex-direction: column;
+	}
+
+	.page-wrapper {
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+		width: 100%;
+		overflow: auto;
+		min-height: 0;
+	}
+</style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -81,17 +81,20 @@
 
 <style>
 	.page {
-		min-height: 100vh;
+		flex: 1;
+		width: 100%;
 		display: flex;
 		align-items: center;
 		justify-content: center;
 		padding: 2rem;
+		max-width: 700px;
+		margin: 0 auto;
+		box-sizing: border-box;
 	}
 
 	.container {
 		max-width: 480px;
 		width: 100%;
-		transform: translateY(-2rem);
 		container-type: inline-size;
 	}
 

--- a/src/routes/[[scope=scope]]/[package]/+page.svelte
+++ b/src/routes/[[scope=scope]]/[package]/+page.svelte
@@ -217,7 +217,8 @@
 
 <style>
 	.page {
-		min-height: 100vh;
+		flex: 1;
+		width: 100%;
 		color: var(--text);
 		max-width: 600px;
 		margin: 0 auto;

--- a/src/routes/package-json/+page.svelte
+++ b/src/routes/package-json/+page.svelte
@@ -292,7 +292,8 @@
 
 <style>
 	.page {
-		min-height: 100vh;
+		flex: 1;
+		width: 100%;
 		color: var(--text);
 		max-width: 700px;
 		margin: 0 auto;

--- a/src/routes/packages/+page.svelte
+++ b/src/routes/packages/+page.svelte
@@ -57,7 +57,8 @@
 
 <style>
 	.page {
-		min-height: 100vh;
+		flex: 1;
+		width: 100%;
 		color: var(--text);
 		max-width: 700px;
 		margin: 0 auto;


### PR DESCRIPTION
## Description


Restructures the page layout so individual `.page` elements no longer rely on `100vh`.

The previous layout caused vertical overflow because `100vh` did not account for surrounding padding and Controls component. This PR moves the full-height behavior into the main layout wrapper and lets pages fill the remaining space via flex growth.


## Screenshots

| Route | Prod | PR |
| ----- | ---- | -- |
| `/` | <img width="2850" height="1778" alt="Production screenshot of the home route" src="https://github.com/user-attachments/assets/64306626-1088-4965-b4e9-b677a003ebd9" /> | <img width="2850" height="1778" alt="PR screenshot of the home route" src="https://github.com/user-attachments/assets/75193880-f2e0-4048-b2ce-9226c3a18f9c" /> |
| `/package-json` | <img width="2850" height="1778" alt="Production screenshot of the package-json route" src="https://github.com/user-attachments/assets/eb1addf4-502e-4bc8-a464-2df1ef373f1b" /> | <img width="2850" height="1778" alt="PR screenshot of the package-json route" src="https://github.com/user-attachments/assets/c6f7e883-6ebd-432b-9dbd-1e018e6c3e5e" /> |
| `/packages` | <img width="2850" height="1778" alt="Production screenshot of the packages route" src="https://github.com/user-attachments/assets/724d6560-2394-4ef3-92f8-98ae7e82994a" /> | <img width="2850" height="1778" alt="PR screenshot of the packages route" src="https://github.com/user-attachments/assets/0f85d94d-d7f0-4bac-a5ad-854138c4767a" /> |
| `/<package>` | <img width="2850" height="1778" alt="Production screenshot of the package detail route" src="https://github.com/user-attachments/assets/fbc9dfc5-c83e-4e17-91fd-f03c3f42c205" /> | <img width="2850" height="1778" alt="PR screenshot of the package detail route" src="https://github.com/user-attachments/assets/a9275015-1c2c-4505-9f1f-751809851399" /> |
| `@eslint/eslint` | <img width="2260" height="1778" alt="image" src="https://github.com/user-attachments/assets/d75dd4bf-fb08-43e2-a038-3a4fe3f6a6ee" /> |  <img width="2290" height="1778" alt="image" src="https://github.com/user-attachments/assets/5d736734-167b-411d-a7ca-9e08d4f6219a" /> |
| `eslint/eslint` | <img width="2290" height="1778" alt="image" src="https://github.com/user-attachments/assets/36f8f4cc-9a89-43a3-a0ce-586adab528da" /> | <img width="2290" height="1778" alt="image" src="https://github.com/user-attachments/assets/13d272dd-8238-49e1-ad0a-e3e703ecd5ef" /> |

No visual discrepancies seen in testing.

The scrollbar is not visible in the screenshots because it auto-hides. However, in production the page can still be scrolled even though there is no additional content to scroll to.