### PR TITLE
fix: show contextual errors for failed GitHub package.json scans

### DIFF
--- a/src/routes/mocks/index.ts
+++ b/src/routes/mocks/index.ts
@@ -86,6 +86,10 @@ matcher.add('https://api.github.com/repos/:owner/:repo', (params) => {
 });
 
 matcher.add('https://raw.githubusercontent.com/:owner/:repo/:branch/*path', (params) => {
+	if (`${params.owner}/${params.repo}/${params.path}` === 'invalid/package-json/package.json') {
+		return new Response('{ "dependencies": {');
+	}
+
 	const package_json = packages[`${params.owner}/${params.repo}/${params.path}`];
 	if (package_json) return new Response(JSON.stringify(package_json));
 

--- a/src/routes/package-json/+page.svelte
+++ b/src/routes/package-json/+page.svelte
@@ -5,6 +5,7 @@
 	import FileInput from '$lib/FileInput.svelte';
 	import ReplacementsTitle from '$lib/ReplacementsTitle.svelte';
 	import { eval_package_json } from '$lib/package-json-scan';
+	import type { PackageJsonScanResult } from '$lib/package-json-scan';
 	import { scopify } from '$lib/utils';
 
 	import { scan_package_json_file } from './data.remote';
@@ -21,9 +22,27 @@
 		return null;
 	});
 
+	function eval_github_package_json(package_json: string | null): PackageJsonScanResult {
+		if (package_json === null) {
+			return { success: false, error: 'package.json not found in this GitHub repository.' };
+		}
+
+		const result = eval_package_json(package_json);
+		// note (ux): A GitHub scan resolves a repository file, rather than an uploaded file.
+		// Use source-specific copy so users know the link resolved but its package.json is malformed.
+		if (!result.success && result.error === 'File was not valid JSON.') {
+			return {
+				success: false,
+				error: 'package.json found in this GitHub repository was not valid JSON.'
+			};
+		}
+
+		return result;
+	}
+
 	// the ternary is here so that we will only wait when the query parameters are actually there
 	const github_result = $derived(
-		github_info ? eval_package_json(await get_repo_package_json(github_info)) : null
+		github_info ? eval_github_package_json(await get_repo_package_json(github_info)) : null
 	);
 
 	// we prioritize github result over the result of the form submission, this is fine because:

--- a/src/routes/package-json/github.remote.ts
+++ b/src/routes/package-json/github.remote.ts
@@ -64,7 +64,7 @@ async function fetch_default_branch(owner: string, repo: string): Promise<string
 export const get_repo_package_json = query(github_info_schema, async (github_info) => {
 	const branch =
 		github_info.branch ?? (await fetch_default_branch(github_info.owner, github_info.repo));
-	if (!branch) return '';
+	if (!branch) return null;
 
 	const repo_package_paths = get_package_json_paths(github_info.path);
 
@@ -79,6 +79,6 @@ export const get_repo_package_json = query(github_info_schema, async (github_inf
 
 		if (package_json) return package_json;
 	}
-	// if no package.json is found we return an empty string so the client shows the not valid JSON UI
-	return '';
+
+	return null;
 });

--- a/tests/app.e2e.ts
+++ b/tests/app.e2e.ts
@@ -437,7 +437,7 @@ test.describe('Package JSON scanner', () => {
 		await expect(page.getByRole('link', { name: /qs/ })).toBeVisible();
 	});
 
-	test('shows invalid JSON error when no GitHub package.json is found in the tree', async ({
+	test('shows not found error when no GitHub package.json is found in the tree', async ({
 		page
 	}) => {
 		await page.goto('/github.com/missing/package-json/blob/main/packages/app/src/index.js');
@@ -446,7 +446,17 @@ test.describe('Package JSON scanner', () => {
 			/package-json\?owner=missing&repo=package-json&branch=main&path=%2Fpackages%2Fapp%2Fsrc$/
 		);
 
-		await expect(page.getByRole('alert')).toContainText('File was not valid JSON.');
+		await expect(page.getByRole('alert')).toContainText(
+			'package.json not found in this GitHub repository.'
+		);
+	});
+
+	test('shows invalid JSON error for a malformed GitHub package.json', async ({ page }) => {
+		await page.goto('/package-json?owner=invalid&repo=package-json&branch=main');
+
+		await expect(page.getByRole('alert')).toContainText(
+			'package.json found in this GitHub repository was not valid JSON.'
+		);
 	});
 });
 


### PR DESCRIPTION
## Linked issue

Resolves #70

## Context

GitHub scans previously returned an empty string when no `package.json` could be resolved. That value was then parsed as JSON, causing the UI to report `File was not valid JSON.` even though no file had been found.

## Description

This PR adds two error modes that previously produced the same validation error:

| Scenario | Message |
| -------- | ------- |
| No `package.json` can be found in the GitHub repository or selected path | `package.json` was not found in this GitHub repository or selected path. |
| A `package.json` is found but contains malformed JSON | `package.json` was found in this GitHub repository or selected path, but was not valid JSON. |

### Before/After

| Scenario | URL | Prod | PR |
| ---- | --- | ---- | -- |
| `package.json` not found | [replacements.fyi/package-json?owner=t128n&repo=not-found](https://replacements.fyi/package-json?owner=t128n&repo=not-found) | <img width="2850" height="1778" alt="image" src="https://github.com/user-attachments/assets/1ee11ac3-a53c-4991-97e4-5b1d11d36258" /> | <img width="2850" height="1778" alt="image" src="https://github.com/user-attachments/assets/55b5b263-7daf-4bef-9eb0-993bec233c8e" /> |
| Invalid `package.json` | [replacements.fyi/package-json?owner=t128n&repo=invalid-package-json](https://replacements.fyi/package-json?owner=t128n&repo=invalid-package-json) | <img width="2850" height="1778" alt="image" src="https://github.com/user-attachments/assets/f9779324-cfb8-4a0b-9864-00d78c382882" /> | <img width="2850" height="1778" alt="image" src="https://github.com/user-attachments/assets/228ad566-9822-4340-a27b-b9ec35bff2fd" /> |