### PR TITLE
feat: add url param for pasted or dropped package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
 	},
 	"dependencies": {
 		"@fontsource/ibm-plex-mono": "^5.2.7",
+		"lz-string": "^1.5.0",
 		"module-replacements": "3.0.0-beta.4",
 		"sveltekit-view-transition": "^0.5.3",
 		"valibot": "^1.3.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@fontsource/ibm-plex-mono':
         specifier: ^5.2.7
         version: 5.2.7
+      lz-string:
+        specifier: ^1.5.0
+        version: 1.5.0
       module-replacements:
         specifier: 3.0.0-beta.4
         version: 3.0.0-beta.4
@@ -1312,6 +1315,10 @@ packages:
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -2892,6 +2899,8 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.21:
     dependencies:

--- a/src/lib/package-json-url.ts
+++ b/src/lib/package-json-url.ts
@@ -1,0 +1,30 @@
+// lz-string ships as CommonJS, so SvelteKit's SSR can't tree-shake named exports.
+// Import the default and destructure to keep both SSR and the client happy.
+import lz_string from 'lz-string';
+
+const {
+	compressToEncodedURIComponent: compress_to_encoded_uri_component,
+	decompressFromEncodedURIComponent: decompress_from_encoded_uri_component
+} = lz_string;
+
+type DepsMap = Record<string, unknown>;
+
+export function encode_deps(
+	dependencies: DepsMap | undefined,
+	dev_dependencies: DepsMap | undefined
+) {
+	const payload: { dependencies?: DepsMap; devDependencies?: DepsMap } = {};
+	if (dependencies && Object.keys(dependencies).length > 0) {
+		payload.dependencies = dependencies;
+	}
+	if (dev_dependencies && Object.keys(dev_dependencies).length > 0) {
+		payload.devDependencies = dev_dependencies;
+	}
+	return compress_to_encoded_uri_component(JSON.stringify(payload));
+}
+
+export function decode_param(param: string) {
+	const decompressed = decompress_from_encoded_uri_component(param);
+	if (!decompressed) return null;
+	return decompressed;
+}

--- a/src/routes/package-json/+page.svelte
+++ b/src/routes/package-json/+page.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
 	import { browser } from '$app/environment';
+	import { goto } from '$app/navigation';
 	import { resolve } from '$app/paths';
 	import { page } from '$app/state';
 	import FileInput from '$lib/FileInput.svelte';
 	import ReplacementsTitle from '$lib/ReplacementsTitle.svelte';
 	import { eval_package_json } from '$lib/package-json-scan';
 	import type { PackageJsonScanResult } from '$lib/package-json-scan';
+	import { decode_param, encode_deps } from '$lib/package-json-url';
 	import { scopify } from '$lib/utils';
 
 	import { scan_package_json_file } from './data.remote';
@@ -45,18 +47,41 @@
 		github_info ? eval_github_package_json(await get_repo_package_json(github_info)) : null
 	);
 
-	// we prioritize github result over the result of the form submission, this is fine because:
+	const config_param = $derived(page.url.searchParams.get('config'));
+
+	const config_result = $derived.by((): PackageJsonScanResult | null => {
+		if (!config_param) return null;
+		const decoded = decode_param(config_param);
+		if (decoded === null) {
+			return { success: false, error: 'Configuration in URL was invalid.' };
+		}
+		return eval_package_json(decoded);
+	});
+
+	// we prioritize github result over config result over the result of the form submission, this is fine because:
 	// 1. if JS is enabled we simply override the value of the variable with the new scan (which means the UI will update with the new scan result)
-	// 2. if JS is not enabled the form submission will navigate to the remote function URL which will override the github search params
+	// 2. if JS is not enabled the form submission will navigate to the remote function URL which will override the github or config search params
 	let scan_result = $derived(
-		github_result ? (github_result.success ? github_result : null) : scan_package_json_file.result
+		github_result
+			? github_result.success
+				? github_result
+				: null
+			: config_result
+				? config_result.success
+					? config_result
+					: null
+				: scan_package_json_file.result
 	);
 	let scan_error = $derived(
 		github_result
 			? github_result.success
 				? ''
 				: github_result.error
-			: scan_package_json_file.fields.package_json.issues()?.[0]?.message || ''
+			: config_result
+				? config_result.success
+					? ''
+					: config_result.error
+				: scan_package_json_file.fields.package_json.issues()?.[0]?.message || ''
 	);
 
 	function package_href(package_name: string) {
@@ -68,12 +93,21 @@
 		package_name?.style.setProperty('view-transition-name', 'package-name');
 	}
 
-	function handle_scan_again(event: MouseEvent) {
-		event.preventDefault();
+	function handle_scan_again() {
 		scan_result = null;
 		scan_error = '';
 		file_name = '';
 		dragging_file = false;
+	}
+
+	async function push_config_to_url(package_json_text: string) {
+		const parsed: {
+			dependencies?: Record<string, unknown>;
+			devDependencies?: Record<string, unknown>;
+		} = JSON.parse(package_json_text);
+		const encoded = encode_deps(parsed.dependencies, parsed.devDependencies);
+		// eslint-disable-next-line svelte/no-navigation-without-resolve
+		await goto(`${resolve('/package-json')}?config=${encoded}`);
 	}
 
 	async function handle_file_change(event: Event & { currentTarget: HTMLInputElement }) {
@@ -85,6 +119,7 @@
 				scan_result = result;
 				scan_error = '';
 				file_name = file.name;
+				await push_config_to_url(text);
 			} else {
 				scan_error = result.error;
 			}
@@ -111,6 +146,7 @@
 				scan_error = '';
 				file_name = '';
 				dragging_file = false;
+				await push_config_to_url(package_json);
 				return;
 			}
 			scan_error = result.error;
@@ -124,6 +160,7 @@
 				scan_error = '';
 				file_name = '';
 				dragging_file = false;
+				await push_config_to_url(text);
 			} else {
 				scan_error = result.error;
 			}
@@ -171,6 +208,7 @@
 				scan_result = result;
 				scan_error = '';
 				file_name = file.name;
+				await push_config_to_url(text);
 			} else {
 				scan_error = result.error;
 			}

--- a/tests/app.e2e.ts
+++ b/tests/app.e2e.ts
@@ -234,6 +234,62 @@ test.describe('Package JSON scanner', () => {
 		await expect(page.getByRole('link', { name: /qs/ })).toBeVisible();
 	});
 
+	test('preserves a dropped package.json in the URL and restores it via the back button', async ({
+		page
+	}) => {
+		await page.goto('/package-json');
+		await expect(page.getByLabel('Upload package.json')).toBeVisible();
+		await expect(page).toHaveURL(/\/package-json$/);
+
+		await paste_package_json(page, {
+			name: 'express',
+			dependencies: {
+				'body-parser': '^2.2.1',
+				debug: '^4.4.0',
+				qs: '^6.14.2'
+			}
+		});
+
+		await expect(page).toHaveURL(/\/package-json\?config=[^&]+$/);
+		await expect(page.getByRole('heading', { name: 'Found 3 replacements' })).toBeVisible();
+
+		await page.getByRole('link', { name: /body-parser/ }).click();
+		await expect(page).toHaveURL(/\/body-parser$/);
+
+		await page.goBack();
+		await expect(page).toHaveURL(/\/package-json\?config=[^&]+$/);
+		await expect(page.getByRole('heading', { name: 'Found 3 replacements' })).toBeVisible();
+		await expect(page.getByRole('link', { name: /body-parser/ })).toBeVisible();
+		await expect(page.getByRole('link', { name: /debug/ })).toBeVisible();
+		await expect(page.getByRole('link', { name: /qs/ })).toBeVisible();
+		await expect(page.getByLabel('Upload package.json')).toHaveCount(0);
+	});
+
+	test('renders results directly from a ?config= URL without an upload', async ({ page }) => {
+		await page.goto('/package-json');
+		await expect(page.getByLabel('Upload package.json')).toBeVisible();
+		await paste_package_json(page, {
+			name: 'express',
+			dependencies: { 'body-parser': '^2.2.1' }
+		});
+		await expect(page.getByRole('heading', { name: 'Found 1 replacements' })).toBeVisible();
+		await expect(page).toHaveURL(/\/package-json\?config=[^&]+$/);
+		const shareable_url = page.url();
+
+		await page.goto('/');
+		await page.goto(shareable_url);
+
+		await expect(page.getByRole('heading', { name: 'Found 1 replacements' })).toBeVisible();
+		await expect(page.getByRole('link', { name: /body-parser/ })).toBeVisible();
+		await expect(page.getByLabel('Upload package.json')).toHaveCount(0);
+	});
+
+	test('shows an error when the ?config= URL parameter is corrupt', async ({ page }) => {
+		await page.goto('/package-json?config=not-a-real-lz-string-payload');
+
+		await expect(page.getByRole('alert')).toContainText('Configuration in URL was invalid.');
+	});
+
 	test('clears previous scan results after navigating away and back', async ({ page }) => {
 		await page.goto('/package-json');
 		await expect(page.getByLabel('Upload package.json')).toBeVisible();


### PR DESCRIPTION
Adds `?config=` param (via `lz-string`)  to url when pasting or dropping package.json config. This preserves the URL history when clicking into a suggested replacement, allowing the user to navigate "Back" to the full replacement list. This is a similar to the existing behavior of using a GitHub URL