### PR TITLE
feat: add persistent URL search bar with npmx-style morph

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
 	"dependencies": {
 		"@fontsource/ibm-plex-mono": "^5.2.7",
 		"module-replacements": "3.0.0-beta.4",
-		"sveltekit-view-transition": "^0.5.3",
 		"valibot": "^1.3.1"
 	},
 	"packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319"

--- a/src/lib/Autocomplete.svelte
+++ b/src/lib/Autocomplete.svelte
@@ -27,12 +27,7 @@
 	let input: HTMLInputElement;
 
 	function select(item: string) {
-		prepare_transition();
 		on_select_navigate_to(item);
-	}
-
-	function prepare_transition() {
-		input.style.setProperty('view-transition-name', 'package-name');
 	}
 
 	function handle_keydown(e: KeyboardEvent) {
@@ -92,7 +87,6 @@
 						class:active={i === active_index}
 						aria-current={i === active_index ? 'true' : undefined}
 						onmousedown={(e) => e.preventDefault()}
-						onclick={prepare_transition}
 					>
 						{item}
 					</a>

--- a/src/lib/PackageSearch.svelte
+++ b/src/lib/PackageSearch.svelte
@@ -1,0 +1,112 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import { resolve } from '$app/paths';
+	import { all } from 'module-replacements';
+	import Autocomplete from '$lib/Autocomplete.svelte';
+	import SingleInputSubmitButton from '$lib/SingleInputSubmitButton.svelte';
+
+	type Props = {
+		variant?: 'hero' | 'url';
+		value?: string;
+		autofocus?: boolean;
+	};
+
+	let { variant = 'url', value = $bindable(''), autofocus = false }: Props = $props();
+
+	const packages = Object.keys(all.mappings);
+
+	const placeholder = $derived(variant === 'hero' ? 'e.g. is-number' : 'package-name');
+
+	function package_href(package_name: string) {
+		return resolve('/[...pkg=package_name]', { pkg: package_name });
+	}
+
+	function navigate_to(package_name: string) {
+		// eslint-disable-next-line svelte/no-navigation-without-resolve
+		goto(package_href(package_name));
+	}
+</script>
+
+<form
+	class="search-form search-box"
+	class:hero={variant === 'hero'}
+	class:url-bar={variant === 'url'}
+	onsubmit={(e) => {
+		e.preventDefault();
+		const form_data = new FormData(e.currentTarget);
+		const package_name = form_data.get('package');
+		if (package_name) {
+			navigate_to(package_name.toString());
+		}
+	}}
+>
+	<a href={resolve('/')} class="origin" aria-label="Home">replacements<span>.fyi</span></a>
+	<span class="slash" aria-hidden="true">/</span>
+	<Autocomplete
+		items={packages}
+		{placeholder}
+		name="package"
+		get_item_href={package_href}
+		on_select_navigate_to={navigate_to}
+		{autofocus}
+		bind:value
+	/>
+	<SingleInputSubmitButton aria-label="Search" />
+</form>
+
+<style>
+	.search-form {
+		display: flex;
+		align-items: center;
+		border: 1px solid var(--border-strong);
+		border-radius: 6px;
+		background: var(--input-bg);
+		overflow: visible;
+		transition: border-color 0.15s;
+		/* Persistent name pairs with setup-search-view-transition (npmx-inspired). */
+		view-transition-name: search-box;
+	}
+
+	.search-form.hero {
+		margin-top: 1.5rem;
+		width: 100%;
+	}
+
+	.search-form.url-bar {
+		margin: 1.5rem;
+		max-width: 600px;
+	}
+
+	.search-form:focus-within {
+		border-color: var(--accent);
+	}
+
+	.origin {
+		flex-shrink: 0;
+		padding: 0.625rem 0 0.625rem 0.75rem;
+		color: var(--text);
+		font-weight: 700;
+		text-decoration: none;
+		font-size: 0.875rem;
+		white-space: nowrap;
+	}
+
+	.origin span {
+		color: var(--subtle);
+	}
+
+	.origin:hover {
+		text-decoration: underline;
+	}
+
+	.slash {
+		color: var(--subtle);
+		flex-shrink: 0;
+		font-size: 0.9375rem;
+		padding: 0.625rem 0;
+	}
+
+	.search-form :global(.autocomplete input) {
+		padding-left: 0.25rem;
+	}
+</style>

--- a/src/lib/ReplacementsTitle.svelte
+++ b/src/lib/ReplacementsTitle.svelte
@@ -9,7 +9,6 @@
 	.replacements-title {
 		color: var(--text);
 		font-weight: 700;
-		view-transition-name: replacements-title;
 		span {
 			color: var(--subtle);
 		}

--- a/src/lib/search-transition.ts
+++ b/src/lib/search-transition.ts
@@ -1,0 +1,7 @@
+import type { Navigation } from '@sveltejs/kit';
+
+export function is_search_bar_morph({ from, to }: Navigation): boolean {
+	const from_home = from?.route?.id === '/';
+	const to_home = to?.route?.id === '/';
+	return from_home !== to_home;
+}

--- a/src/lib/setup-search-view-transition.ts
+++ b/src/lib/setup-search-view-transition.ts
@@ -1,0 +1,22 @@
+import { browser } from '$app/environment';
+import { onNavigate } from '$app/navigation';
+import { is_search_bar_morph } from '$lib/search-transition';
+
+// Search-bar morph on home ↔ inner pages is inspired by npmx.dev:
+// https://github.com/npmx-dev/npmx.dev/blob/master/app/plugins/view-transitions.client.ts
+// https://github.com/npmx-dev/npmx.dev/blob/master/app/assets/main.css
+export function setup_search_view_transition() {
+	if (!browser || !document.startViewTransition) return;
+
+	onNavigate((navigation) => {
+		if (!is_search_bar_morph(navigation)) return;
+		if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
+		return new Promise<void>((resolve) => {
+			document.startViewTransition(async () => {
+				resolve();
+				await navigation.complete;
+			});
+		});
+	});
+}

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import { page } from '$app/state';
 	import { resolve } from '$app/paths';
-	import ReplacementsTitle from '$lib/ReplacementsTitle.svelte';
+	import { page } from '$app/state';
+	import PackageSearch from '$lib/PackageSearch.svelte';
 
 	const error_message = $derived(page.error?.message ?? 'An error occurred');
 	const package_name = $derived.by(() => {
@@ -15,7 +15,7 @@
 	<title>{page.status} - replacements.fyi</title>
 </svelte:head>
 
-<a href={resolve('/')} class="back-link"><ReplacementsTitle /></a>
+<PackageSearch value={package_name ?? ''} />
 
 <main class="page">
 	<header>
@@ -50,17 +50,6 @@
 
 	a {
 		text-decoration: none;
-	}
-
-	.back-link {
-		color: var(--accent);
-		font-size: 1rem;
-		display: inline-block;
-		margin: 1.5rem;
-	}
-
-	.back-link:hover {
-		text-decoration: underline;
 	}
 
 	.comment {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -8,10 +8,10 @@
 	import '@fontsource/ibm-plex-mono/700.css';
 	import favicon from '$lib/assets/favicon.svg';
 	import Controls from '$lib/Controls.svelte';
+	import { setup_search_view_transition } from '$lib/setup-search-view-transition';
 	import './global.css';
-	import { setupViewTransition } from 'sveltekit-view-transition';
 
-	setupViewTransition();
+	setup_search_view_transition();
 
 	let { children } = $props();
 </script>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,21 +1,12 @@
 <script lang="ts">
-	import { goto } from '$app/navigation';
 	import { resolve } from '$app/paths';
-	import { all } from 'module-replacements';
-	import Autocomplete from '$lib/Autocomplete.svelte';
+	import PackageSearch from '$lib/PackageSearch.svelte';
 	import ReplacementsTitle from '$lib/ReplacementsTitle.svelte';
-	import SingleInputSubmitButton from '$lib/SingleInputSubmitButton.svelte';
 
 	const examples = ['is-number', 'left-pad', 'is-odd', 'object-assign'];
-	const packages = Object.keys(all.mappings);
 
 	function package_href(package_name: string) {
 		return resolve('/[...pkg=package_name]', { pkg: package_name });
-	}
-
-	function navigate_to(package_name: string) {
-		// eslint-disable-next-line svelte/no-navigation-without-resolve
-		goto(package_href(package_name));
 	}
 </script>
 
@@ -35,29 +26,7 @@
 
 		<p class="tagline">type a package name. we'll tell you what you don't need.</p>
 
-		<form
-			onsubmit={(e) => {
-				e.preventDefault();
-				const form_data = new FormData(e.currentTarget);
-				const package_name = form_data.get('package');
-				if (package_name) {
-					const input = e.currentTarget.querySelector('input')!;
-					input.style.setProperty('view-transition-name', 'package-name');
-					navigate_to(package_name.toString());
-				}
-			}}
-			class="search-form"
-		>
-			<Autocomplete
-				items={packages}
-				placeholder="e.g. is-number"
-				name="package"
-				get_item_href={package_href}
-				on_select_navigate_to={navigate_to}
-				autofocus
-			/>
-			<SingleInputSubmitButton aria-label="Search" />
-		</form>
+		<PackageSearch variant="hero" autofocus />
 
 		<div class="examples">
 			<span class="examples-header">// examples</span>
@@ -118,21 +87,6 @@
 		font-size: 0.875rem;
 		margin: 1.5rem 0 0;
 		line-height: 1.5;
-	}
-
-	.search-form {
-		display: flex;
-		align-items: center;
-		margin-top: 1.5rem;
-		border: 1px solid var(--border-strong);
-		border-radius: 6px;
-		background: var(--input-bg);
-		overflow: visible;
-		transition: border-color 0.15s;
-	}
-
-	.search-form:focus-within {
-		border-color: var(--accent);
 	}
 
 	.examples {

--- a/src/routes/[...pkg=package_name]/+page.svelte
+++ b/src/routes/[...pkg=package_name]/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { resolve } from '$app/paths';
 	import { error } from '@sveltejs/kit';
 	import {
 		all,
@@ -10,7 +9,7 @@
 		type ModuleReplacement
 	} from 'module-replacements';
 	import { highlight } from './highlight.remote';
-	import ReplacementsTitle from '$lib/ReplacementsTitle.svelte';
+	import PackageSearch from '$lib/PackageSearch.svelte';
 	import RuntimeToggle from '$lib/RuntimeToggle.svelte';
 	import { browser_engines, runtime_engines, engines_match_runtime } from '$lib/engines';
 	import { runtime } from '$lib/runtime.svelte';
@@ -90,7 +89,7 @@
 	<meta name="description" content="Replacements for the '{package_name}' npm package." />
 </svelte:head>
 
-<a href={resolve('/')} class="back-link"><ReplacementsTitle /></a>
+<PackageSearch value={package_name} />
 <main class="page">
 	<header class="pkg-header">
 		<p class="comment">// package</p>
@@ -209,23 +208,8 @@
 		box-sizing: border-box;
 	}
 
-	.pkg {
-		view-transition-name: package-name;
-	}
-
 	a {
 		text-decoration: none;
-	}
-
-	.back-link {
-		color: var(--accent);
-		font-size: 1rem;
-		display: inline-block;
-		margin: 1.5rem;
-	}
-
-	.back-link:hover {
-		text-decoration: underline;
 	}
 
 	.comment {

--- a/src/routes/global.css
+++ b/src/routes/global.css
@@ -1,11 +1,20 @@
-@view-transition {
-	navigation: auto;
+/* npmx-inspired search-box morph: disable root crossfade, animate search-box only. */
+::view-transition-old(root),
+::view-transition-new(root) {
+	animation: none;
 }
 
-::view-transition-old(package-name),
-::view-transition-new(package-name) {
-	height: 100%;
-	width: auto;
+::view-transition-old(search-box),
+::view-transition-new(search-box) {
+	animation-duration: 0.3s;
+	animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+	::view-transition-old(search-box),
+	::view-transition-new(search-box) {
+		animation: none;
+	}
 }
 
 :root {

--- a/src/routes/package-json/+page.svelte
+++ b/src/routes/package-json/+page.svelte
@@ -258,10 +258,7 @@
 					{#each scan_result.replacements as replacement, i (replacement.dep)}
 						<li style:--i={i}>
 							<!-- eslint-disable svelte/no-navigation-without-resolve -->
-							<a
-								href={package_href(replacement.replacement.moduleName)}
-								class="replacement-link"
-							>
+							<a href={package_href(replacement.replacement.moduleName)} class="replacement-link">
 								<span class="replacement-copy">
 									<span class="package-name">{replacement.dep}</span>
 									<span class="replacement-target"

--- a/src/routes/package-json/+page.svelte
+++ b/src/routes/package-json/+page.svelte
@@ -3,7 +3,7 @@
 	import { resolve } from '$app/paths';
 	import { page } from '$app/state';
 	import FileInput from '$lib/FileInput.svelte';
-	import ReplacementsTitle from '$lib/ReplacementsTitle.svelte';
+	import PackageSearch from '$lib/PackageSearch.svelte';
 	import { eval_package_json } from '$lib/package-json-scan';
 	import type { PackageJsonScanResult } from '$lib/package-json-scan';
 
@@ -60,11 +60,6 @@
 
 	function package_href(package_name: string) {
 		return resolve('/[...pkg=package_name]', { pkg: package_name });
-	}
-
-	function add_view_transition_name(link: HTMLAnchorElement) {
-		const package_name = link.querySelector<HTMLElement>('.package-name');
-		package_name?.style.setProperty('view-transition-name', 'package-name');
 	}
 
 	function handle_scan_again(event: MouseEvent) {
@@ -190,7 +185,7 @@
 	<meta name="description" content="Scan a package.json for replacements." />
 </svelte:head>
 
-<a href={resolve('/')} class="back-link"><ReplacementsTitle /></a>
+<PackageSearch />
 
 <main class="page">
 	<header class="header">
@@ -264,9 +259,6 @@
 						<li style:--i={i}>
 							<!-- eslint-disable svelte/no-navigation-without-resolve -->
 							<a
-								onclick={(e) => {
-									add_view_transition_name(e.currentTarget);
-								}}
 								href={package_href(replacement.replacement.moduleName)}
 								class="replacement-link"
 							>
@@ -317,19 +309,8 @@
 		padding: 2rem;
 	}
 
-	.back-link {
-		color: var(--accent);
-		font-size: 1rem;
-		display: inline-block;
-		margin: 1.5rem;
-	}
-
 	a {
 		text-decoration: none;
-	}
-
-	.back-link:hover {
-		text-decoration: underline;
 	}
 
 	.header {

--- a/src/routes/packages/+page.svelte
+++ b/src/routes/packages/+page.svelte
@@ -2,7 +2,7 @@
 	import { resolve } from '$app/paths';
 	import { all } from 'module-replacements';
 	import FilterInput from '$lib/FilterInput.svelte';
-	import ReplacementsTitle from '$lib/ReplacementsTitle.svelte';
+	import PackageSearch from '$lib/PackageSearch.svelte';
 
 	const packages = Object.keys(all.mappings).sort();
 
@@ -20,7 +20,7 @@
 	<meta name="description" content="Browse all npm packages with replacements." />
 </svelte:head>
 
-<a href={resolve('/')} class="back-link"><ReplacementsTitle /></a>
+<PackageSearch />
 
 <main class="page">
 	<header class="header">
@@ -37,9 +37,6 @@
 		{#each filtered_packages as pkg (pkg)}
 			<li>
 				<a
-					onclick={(e) => {
-						e.currentTarget.style.setProperty('view-transition-name', 'package-name');
-					}}
 					href={resolve('/[...pkg=package_name]', { pkg })}
 					class="package-link"
 				>
@@ -65,17 +62,6 @@
 
 	a {
 		text-decoration: none;
-	}
-
-	.back-link {
-		color: var(--accent);
-		font-size: 1rem;
-		display: inline-block;
-		margin: 1.5rem;
-	}
-
-	.back-link:hover {
-		text-decoration: underline;
 	}
 
 	.header {

--- a/src/routes/packages/+page.svelte
+++ b/src/routes/packages/+page.svelte
@@ -36,10 +36,7 @@
 	<ul class="package-list">
 		{#each filtered_packages as pkg (pkg)}
 			<li>
-				<a
-					href={resolve('/[...pkg=package_name]', { pkg })}
-					class="package-link"
-				>
+				<a href={resolve('/[...pkg=package_name]', { pkg })} class="package-link">
 					<span class="package-name">{pkg}</span>
 				</a>
 			</li>

--- a/tests/app.e2e.ts
+++ b/tests/app.e2e.ts
@@ -88,11 +88,46 @@ test.describe('Package detail page', () => {
 		await expect(page.getByText("we don't have a replacement")).toContainText('"@eslint/eslint"');
 	});
 
-	test('back link navigates home', async ({ page }) => {
+	test('home link navigates home', async ({ page }) => {
 		await page.goto('/is-number');
-		// The back link contains "mr.e18e" text
-		await page.locator('.back-link').click();
+		await page.getByRole('link', { name: 'Home' }).click();
 		await expect(page).toHaveURL('/');
+	});
+
+	test('search input is visible and navigates to another package', async ({ page }) => {
+		await page.goto('/is-number');
+		const input = page.locator('input[name="package"]');
+		await expect(input).toBeVisible();
+		await expect(input).toHaveValue('is-number');
+		await input.fill('left-pad');
+		await page.getByRole('button', { name: 'Search' }).click();
+		await expect(page).toHaveURL(/\/left-pad/);
+	});
+
+	test('autocomplete from detail page navigates without going home', async ({ page }) => {
+		await page.goto('/is-number');
+		const input = page.locator('input[name="package"]');
+		await input.fill('is-o');
+		await page.locator('.suggestions a', { hasText: 'is-odd' }).first().click();
+		await expect(page).toHaveURL(/\/is-odd/);
+	});
+	test('search input is visible on 404 page', async ({ page }) => {
+		await page.goto('/this-package-does-not-exist-xyz');
+		const input = page.locator('input[name="package"]');
+		await expect(input).toBeVisible();
+		await expect(input).toHaveValue('this-package-does-not-exist-xyz');
+	});
+});
+
+test.describe('Inner pages search', () => {
+	test('search input is visible on packages page', async ({ page }) => {
+		await page.goto('/packages');
+		await expect(page.locator('input[name="package"]')).toBeVisible();
+	});
+
+	test('search input is visible on package-json page', async ({ page }) => {
+		await page.goto('/package-json');
+		await expect(page.locator('input[name="package"]')).toBeVisible();
 	});
 });
 


### PR DESCRIPTION
adds `PackageSearch` to inner pages so users can search without returning home. the bar morphs from the centered homepage to the top-left navbar on home, following npmx.dev's view transition pattern.

closes: #76 

