### PR TITLE
feat: add feeling lucky button

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,17 +1,31 @@
 <script lang="ts">
+	import { afterNavigate } from '$app/navigation';
 	import { resolve } from '$app/paths';
 	import PackageSearch from '$lib/PackageSearch.svelte';
 	import ReplacementsTitle from '$lib/ReplacementsTitle.svelte';
+	import { all } from 'module-replacements';
 
 	const examples = ['is-number', 'left-pad', 'is-odd', 'object-assign'];
+	const all_packages = Object.keys(all.mappings);
+
+	let random_pkg = $state(all_packages[0] ?? '');
 
 	function package_href(package_name: string) {
 		return resolve('/[...pkg=package_name]', { pkg: package_name });
 	}
+
+	function get_random_package() {
+		if (all_packages.length === 0) return '';
+		return all_packages[Math.floor(Math.random() * all_packages.length)];
+	}
+
+	afterNavigate(() => {
+		random_pkg = get_random_package();
+	});
 </script>
 
-<main class="page">
-	<div class="container">
+<div class="page">
+	<main class="container">
 		<header>
 			<div class="title">
 				<ReplacementsTitle />
@@ -38,28 +52,40 @@
 			</ul>
 		</div>
 
-		<a href="https://e18e.dev" class="powered-by" target="_blank" rel="noopener"
-			>powered by e18e.dev</a
-		>
+		<div class="actions">
+			<div class="nav-group" role="group" aria-label="Quick Navigation">
+				<a href={resolve('/packages')} class="seg">Browse all</a>
+				<a href={resolve('/package-json')} class="seg">Scan package.json</a>
+				<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+				<a href={resolve('/[...pkg=package_name]', { pkg: random_pkg })} class="seg">
+					I'm feeling lucky
+				</a>
+			</div>
+		</div>
+	</main>
 
-		<a href={resolve('/packages')} class="all-packages-link">Browse all packages →</a>
-		<a href={resolve('/package-json')} class="all-packages-link">Scan package.json →</a>
-	</div>
-</main>
+	<footer class="footer">
+		<a href="https://e18e.dev" class="powered-by" target="_blank" rel="noopener">
+			powered by e18e.dev
+		</a>
+	</footer>
+</div>
 
 <style>
 	.page {
-		min-height: 100vh;
+		height: 100dvh;
+		box-sizing: border-box;
 		display: flex;
-		align-items: center;
-		justify-content: center;
-		padding: 2rem;
+		flex-direction: column;
+		justify-content: space-between;
+		padding: 1.5rem 2rem;
+		overflow-y: auto;
 	}
 
 	.container {
 		max-width: 480px;
 		width: 100%;
-		transform: translateY(-2rem);
+		margin: auto;
 		container-type: inline-size;
 	}
 
@@ -126,28 +152,62 @@
 		text-decoration: underline;
 	}
 
+	.actions {
+		margin-top: 2.5rem;
+		display: flex;
+		justify-content: center;
+	}
+
+	.nav-group {
+		display: inline-flex;
+		align-items: stretch;
+		border: 1px solid var(--border);
+		border-radius: 6px;
+		overflow: hidden;
+		background: var(--surface);
+		height: 32px;
+	}
+
+	.seg {
+		display: inline-flex;
+		align-items: center;
+		background: none;
+		border: none;
+		color: var(--subtle-contrast);
+		font-family: inherit;
+		font-size: 0.75rem;
+		padding: 0 0.75rem;
+		cursor: pointer;
+		line-height: 1;
+		text-decoration: none;
+		transition:
+			color 0.15s,
+			background 0.15s;
+	}
+
+	.seg + .seg {
+		border-left: 1px solid var(--border);
+	}
+
+	.seg:hover {
+		color: var(--accent-contrast);
+		background: color-mix(in srgb, var(--accent) 10%, transparent);
+	}
+
+	.footer {
+		flex-shrink: 0;
+		display: flex;
+		justify-content: center;
+		padding-top: 1rem;
+	}
+
 	.powered-by {
-		display: block;
-		margin-top: 3rem;
 		color: var(--subtle);
 		font-size: 0.75rem;
 		text-decoration: none;
 	}
 
 	.powered-by:hover {
-		text-decoration: underline;
-	}
-
-	.all-packages-link {
-		display: block;
-		text-align: center;
-		margin-top: 2rem;
-		color: var(--accent);
-		font-size: 0.875rem;
-		text-decoration: none;
-	}
-
-	.all-packages-link:hover {
 		text-decoration: underline;
 	}
 </style>

--- a/tests/app.e2e.ts
+++ b/tests/app.e2e.ts
@@ -18,16 +18,17 @@ test.describe('Home page', () => {
 		await expect(link).toHaveAttribute('href', /e18e\.dev/);
 	});
 
-	test('has package navigation links', async ({ page }) => {
+	test('has quick navigation group links', async ({ page }) => {
 		await page.goto('/');
-		await expect(page.getByRole('link', { name: 'Browse all packages →' })).toHaveAttribute(
+		const nav_group = page.getByRole('group', { name: 'Quick Navigation' });
+		await expect(nav_group.getByRole('link', { name: 'Browse all', exact: true })).toHaveAttribute(
 			'href',
 			'/packages'
 		);
-		await expect(page.getByRole('link', { name: 'Scan package.json →' })).toHaveAttribute(
-			'href',
-			'/package-json'
-		);
+		await expect(
+			nav_group.getByRole('link', { name: 'Scan package.json', exact: true })
+		).toHaveAttribute('href', '/package-json');
+		await expect(nav_group.getByRole('link', { name: "I'm feeling lucky" })).toBeVisible();
 	});
 
 	test('typing in search shows autocomplete suggestions', async ({ page }) => {
@@ -297,7 +298,7 @@ test.describe('Package JSON scanner', () => {
 
 		await expect(page.getByRole('heading', { name: 'Found 3 replacements' })).toBeVisible();
 		await page.goto('/');
-		await page.getByRole('link', { name: 'Scan package.json →' }).click();
+		await page.getByRole('link', { name: 'Scan package.json' }).click();
 
 		await expect(page.getByRole('heading', { name: 'Found 3 replacements' })).toHaveCount(0);
 		await expect(page.getByText('Paste the content of your package.json or')).toBeVisible();


### PR DESCRIPTION
#### Description

This PR adds a `"I'm feeling lucky"` link to the index page, which picks a truly random package `afterNavigate` so browser back navigations are also handled correctly every time the page is displayed again.

I chose to do it truly random for now instead of pseudo random, alto I noticed that `lodash` packages do naturally get picked more often because we have a lot of individual replacements for it. If users report in the future that they would expect a more "balanced" randomness, we can always improve it to apply some negative weights to packages that have similar names.

While implementing the new link (it's not a button for accessibility reasons), I decided to redesign the landing page a little bit:

<img width="1446" height="929" alt="image" src="https://github.com/user-attachments/assets/5d1470e0-bd05-4711-9bdd-33d3b2dac22d" />

- Closes #56 